### PR TITLE
update certbot install instructions

### DIFF
--- a/up-and-running.md
+++ b/up-and-running.md
@@ -172,8 +172,10 @@ Once done, press ^X, type `Y` and hit Enter to save your changes.
 
 On Ubuntu systems, the Certbot team maintains a PPA. Once you add it to your list of repositories all you'll need to do is apt-get the following packages:
 
-`sudo add-apt-repository ppa:certbot/certbot`
-`sudo apt-get update`
+```
+sudo add-apt-repository ppa:certbot/certbot
+sudo apt-get update
+```
 
 Now we can install Certbot:
 

--- a/up-and-running.md
+++ b/up-and-running.md
@@ -168,17 +168,22 @@ Find all intances of `example.com` and replace with the domain name you have poi
 
 Once done, press ^X, type `Y` and hit Enter to save your changes.
 
-## Setup SSL/HTTPS with Let's Encrypt
+## Setup SSL/HTTPS with Certbot
 
-First, stop the nginx service:
+On Ubuntu systems, the Certbot team maintains a PPA. Once you add it to your list of repositories all you'll need to do is apt-get the following packages:
+
+`sudo add-apt-repository ppa:certbot/certbot`
+`sudo apt-get update`
+
+Now we can install Certbot:
+
+`sudo apt-get install certbot`
+
+Once installed, we can generate the SSL certificates. First you'll need to stop your nginx server so that Certbot can run its standalone authenticator:
 
 `sudo systemctl stop nginx.service`
 
-Now we can install Let's Encrypt:
-
-`sudo apt-get install letsencrypt`
-
-Once installed, we can generate the SSL certificates. Run the following command replacing `example.com` with the domain you have pointed at your machine:
+Then simply run the following command replacing `example.com` with the domain you have pointed at your machine:
 
 `sudo letsencrypt certonly --standalone -d example.com`
 


### PR DESCRIPTION
I've updated your instructions to better reflect how to install certbot on ubuntu based on certbot.eff.org

I'd still recommend webroot (if it works with your nginx config) instead of standalone as it'll mean not stopping your nginx service.

You should also have instructions on how to setup a cronjob for renewal! (otherwise the certs will go invalid)