### PR TITLE
More guide changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Guided tutorials for setting up, running and managing your own [Mastodon](https:
 ## ⌨️ Guides
 
 - **Read this first:** [Running a Mastodon instance on Ubuntu 16.04 with Docker & nginx](https://github.com/ummjackson/mastodon-guide/blob/master/up-and-running.md)
+- [Troubleshooting your instance](https://github.com/ummjackson/mastodon-guide/blob/master/troubleshooting.md)
 - [Converting your instance to single user mode](https://github.com/ummjackson/mastodon-guide/blob/master/single-user-mode.md)
 - [Updating your instance](https://github.com/ummjackson/mastodon-guide/blob/master/updating.md)
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,0 +1,63 @@
+# Troubleshooting
+
+This page lists possible issues you may encounter while setting up or managing a Mastodon instance, and how to fix them.
+
+## Webpacker compliation error
+
+If you're getting an error during the compilation process (like `The code generator has deoptimised the styling of "/mastodon/node_modules/emoji-mart/dist-es/data/data.js" as it exceeds the max of "500KB"`), you need more RAM. This can be solved by following the steps in the "Create temporary swap file" section.
+
+## Running out of space
+
+If your server is running out of space, it's possible the cron job designed to clean up temporary files is not running. Run this command to see the entire cron file for `root`:
+
+`sudo crontab -l`
+
+This line should be somewhere in the file (if not, add it):
+
+`0 0 * * * /home/mastodon/mastodon_cron > /home/mastodon/mastodon_log`
+
+To clear up files manually, you can just run `/home/mastodon/mastodon_cron` at any time.
+
+## Error uploading profile picture/background/other images
+
+If you see an error message when you try to upload a profile picture, profile background, or other images, you may need to update permissions for the public/system folder. Make sure you are logged into the `mastodon` user, and run this command:
+
+`sudo chown -R 991:991 /home/mastodon/mastodon/public/system`
+
+## The site loads but looks funky / doesn't respond properly
+
+If you are seeing server errors or assets not rendering on the frontend, something might just need a gentle push to rebuild and start working. 
+
+A good first step is to run this block of commands **one line at a time** from your `/home/mastodon/mastodon` directory, making sure none of them fail - then check https://your.domain again to see if things are working.
+
+```
+docker-compose down
+docker-compose build
+docker-compose run --rm web rails assets:precompile
+docker-compose run --rm web rails db:migrate
+docker-compose up -d
+sudo systemctl restart nginx.service
+```
+
+**Note:** `docker-compose down` will remove all containers, meaning it will clear out the database. If you'd like to avoid potential data loss, substitute it with `docker-compose stop`. This is less of an issue for a fresh install, but you'll want to switch to the latter once you have registered users.
+
+## Email confirmation isn't working
+
+### Is your host blacklisted?
+
+Some mail hosts will blacklist or bounce emails coming from newly created email addresses or domains. Thankfully Mailgun will try sending these messages again and it should eventually get through.
+
+If you are not receiving emails and need to confirm a user account, go to the "Logs" tab inside the Mailgun UI and click your domain. You should see a green row with the verification email that it attempted to send. Click the cog icon to the left of the row and then "View Message", from here you can manually copy/paste the confirmation URL into your browser to get around this problem.
+
+After your instance is live for ~24 hours, you shouldn't be having this issue any longer. 
+
+### Is your SMTP sending port blocked?
+
+Some ISPs and hosts such as Scaleway block email sending on the standard SMTP port, `25`. To see if that's happening view the web container's logs using `docker logs mastodon_web_1` and look for connection timeouts. To correct this edit the `.env.production` configuration file and change `SMTP_PORT: 25` to port `2525`, which Mailgun and SparkPost support.
+
+After doing so you'll need to rebuild the containers:
+```
+docker-compose stop
+docker-compose build
+docker-compose up -d
+```

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -61,3 +61,33 @@ docker-compose stop
 docker-compose build
 docker-compose up -d
 ```
+
+## 502 Bad Gateway
+
+If you see a 502 error on your instance, it probably means the Ruby server for Mastodon hasn't started properly. Restarting the Docker container usually fixes it. Log into the `mastodon` user, and run these commands:
+
+```
+cd /home/mastodon/mastodon
+docker-compose down
+docker-compse up -d
+```
+
+Wait a few minutes for the changes to take effect. If you're still having issues, run `docker-compose` without the `-d` part, so you'll see all log messages as the Docker runs. If you need to exit, press CTRL-C and then restart the container with the normal `docker-compose up -d` command.
+
+### A server is already running
+
+You might see the following message in the Docker log:
+
+```
+web_1 | A server is already running. Check /mastodon/tmp/pids/server.pid.
+```
+
+You might see this if you restart the server after it was improperly shut down, or if you restore from a backup. Basically, Ruby thinks the server is already running because it found a process ID in the /tmp folder.
+
+To fix this problem, start the Mastodon Docker container using `docker-compse up -d` (if you haven't already), then run this command:
+
+```
+docker exec -it mastodon_web_1 rm /mastodon/tmp/pids/server.pid
+```
+
+This will delete the `server.pid` file in the web Docker container, allowing the server to once again start.

--- a/up-and-running.md
+++ b/up-and-running.md
@@ -247,6 +247,7 @@ Copy/paste in everything below:
 ```
 cd /home/mastodon/mastodon
 docker-compose run --rm web rake mastodon:media:clear
+docker-compose run --rm web rake mastodon:media:remove_remote
 docker-compose run --rm web rake mastodon:push:refresh
 docker-compose run --rm web rake mastodon:push:clear
 docker-compose run --rm web rake mastodon:feeds:clear
@@ -309,7 +310,19 @@ Logout and log back in again, then visit your.domain/admin/settings to start cus
 
 If you're getting an error during the compilation process (like `The code generator has deoptimised the styling of "/mastodon/node_modules/emoji-mart/dist-es/data/data.js" as it exceeds the max of "500KB"`), you need more RAM. This can be solved by following the steps in the "Create temporary swap file" section.
 
-## Error uploading profile picture/background/other images
+### Running out of space
+
+If your server is running out of space, it's possible the cron job designed to clean up temporary files is not running. Run this command to see the entire cron file for `root`:
+
+`sudo crontab -l`
+
+This line should be somewhere in the file (if not, add it):
+
+`0 0 * * * /home/mastodon/mastodon_cron > /home/mastodon/mastodon_log`
+
+To clear up files manually, you can just run `/home/mastodon/mastodon_cron` at any time.
+
+### Error uploading profile picture/background/other images
 
 If you see an error message when you try to upload a profile picture, profile background, or other images, you may need to update permissions for the public/system folder. Make sure you are logged into the `mastodon` user, and run this command:
 

--- a/up-and-running.md
+++ b/up-and-running.md
@@ -300,68 +300,6 @@ Then run this command:
 
 Logout and log back in again, then visit your.domain/admin/settings to start customizing your instance.
 
-### Other guides
-
-- [Converting your instance to single user mode](https://github.com/ummjackson/mastodon-guide/blob/master/single-user-mode.md)
-
 ## Troubleshooting
 
-### Webpacker compliation error
-
-If you're getting an error during the compilation process (like `The code generator has deoptimised the styling of "/mastodon/node_modules/emoji-mart/dist-es/data/data.js" as it exceeds the max of "500KB"`), you need more RAM. This can be solved by following the steps in the "Create temporary swap file" section.
-
-### Running out of space
-
-If your server is running out of space, it's possible the cron job designed to clean up temporary files is not running. Run this command to see the entire cron file for `root`:
-
-`sudo crontab -l`
-
-This line should be somewhere in the file (if not, add it):
-
-`0 0 * * * /home/mastodon/mastodon_cron > /home/mastodon/mastodon_log`
-
-To clear up files manually, you can just run `/home/mastodon/mastodon_cron` at any time.
-
-### Error uploading profile picture/background/other images
-
-If you see an error message when you try to upload a profile picture, profile background, or other images, you may need to update permissions for the public/system folder. Make sure you are logged into the `mastodon` user, and run this command:
-
-`sudo chown -R 991:991 /home/mastodon/mastodon/public/system`
-
-### The site loads but looks funky / doesn't respond properly
-
-If you are seeing server errors or assets not rendering on the frontend, something might just need a gentle push to rebuild and start working. 
-
-A good first step is to run this block of commands **one line at a time** from your `/home/mastodon/mastodon` directory, making sure none of them fail - then check https://your.domain again to see if things are working.
-
-```
-docker-compose down
-docker-compose build
-docker-compose run --rm web rails assets:precompile
-docker-compose run --rm web rails db:migrate
-docker-compose up -d
-sudo systemctl restart nginx.service
-```
-
-**Note:** `docker-compose down` will remove all containers, meaning it will clear out the database. If you'd like to avoid potential data loss, substitute it with `docker-compose stop`. This is less of an issue for a fresh install, but you'll want to switch to the latter once you have registered users.
-
-### Email confirmation isn't working
-
-#### Is your host blacklisted?
-
-Some mail hosts will blacklist or bounce emails coming from newly created email addresses or domains. Thankfully Mailgun will try sending these messages again and it should eventually get through.
-
-If you are not receiving emails and need to confirm a user account, go to the "Logs" tab inside the Mailgun UI and click your domain. You should see a green row with the verification email that it attempted to send. Click the cog icon to the left of the row and then "View Message", from here you can manually copy/paste the confirmation URL into your browser to get around this problem.
-
-After your instance is live for ~24 hours, you shouldn't be having this issue any longer. 
-
-#### Is your SMTP sending port blocked?
-
-Some ISPs and hosts such as Scaleway block email sending on the standard SMTP port, `25`. To see if that's happening view the web container's logs using `docker logs mastodon_web_1` and look for connection timeouts. To correct this edit the `.env.production` configuration file and change `SMTP_PORT: 25` to port `2525`, which Mailgun and SparkPost support.
-
-After doing so you'll need to rebuild the containers:
-```
-docker-compose stop
-docker-compose build
-docker-compose up -d
-```
+If you have any problems during (or after setup), please see the [Troubleshooting page](https://github.com/ummjackson/mastodon-guide/blob/master/troubleshooting.md).

--- a/updating.md
+++ b/updating.md
@@ -34,19 +34,34 @@ docker-compose stop
 
 ## Updating the local files
 
-Next, we need to download the new version of Mastodon, using Git. First, make sure you're on the `master` branch:
+Next, we need to download the new version of Mastodon, using Git. First, update the list of tags in git:
 
 ```
-git status
+git fetch --tags
 ```
 
-You should see a message like `On branch master`. Now, we need to update our local files to match the master branch:
+You should see a list of releases, like this:
 
 ```
-git pull origin master
+v2.3.1
+v2.3.1rc1
+v2.3.1rc2
+v2.3.1rc3
+v2.3.2
+v2.3.2rc1
+v2.3.2rc2
+v2.3.2rc3
+v2.3.2rc4
+v2.3.2rc5
 ```
 
-Now you've finished downloading the latest version of Mastodon! It's time to compile it.
+You need to switch your local copy to the latest release (ignore the RC versions). For example, if v2.3.2 is the latest version, you would run this:
+
+```
+git checkout tags/v2.3.2
+```
+
+
 
 ## Create temporary swap file (optional)
 


### PR DESCRIPTION
My instance kept running out of space and I couldn't figure out why. It turns out this guide doesn't include the `mastodon:media:remove_remote` command in the cron job, so I added it.

I also moved the troubleshooting instructions to a new page, and added tips for dealing with 502 errors.